### PR TITLE
Commit codegolf RPN with all iterations

### DIFF
--- a/2022-09-26-rpn/eu/codegolf/codegolf.rb
+++ b/2022-09-26-rpn/eu/codegolf/codegolf.rb
@@ -1,0 +1,16 @@
+# f=->s{t=[];a=s.split;while(n=a.shift);/\d/=~n&&t.push(n.to_i)||t[-1]=t[-2].send(n,t.pop);end;t[0]}
+# f=->s{t=[];a=s.split;while(n,*a=a;n);/\d/=~n&&t.<<(n)||t[-1]=eval(t[-2]+n+t.pop).to_s;end;t[0]}
+# f=->s{t=[];a=s.split;while(n,*a=a;n);/\d/=~n&&t.push(n.to_i)||t=[*t[..-3],t[-2..].inject(&n)];end;t[0]}
+# f=->s{t=[];a=s.split;while(n,*a=a;n);/\d/=~n&&t<<(n.to_i)||t[-1]=t[-2].send(n,t.pop);end;t[0]}
+# f=->s{s.split.inject([]){|t,n|[*t[..-3],t[-2..].inject(&:"#{n}")] rescue [*t,n.to_i]}[0]}
+# f=->s{s.split.inject([]){|t,n|/\d/=~n&&t<<(n.to_i)||t[-1]=t[-2].send(n,t.pop);t}[0]}
+# f=->s{s.split.inject([]){|t,n|/\d/=~n ?[*t,n.to_i]:[*t[..-3],t[-2].send(n,t.pop)]}[0]}
+# f=->s{s.split.inject([]){|t,n|/\d/=~n ?[*t,n.to_i]:[*t[..-3],eval(t[-2..]*n)]}[0]}
+
+f=->s{s.split.inject([]){|t,n|n=~/\d/?[*t,n.to_i]:[*t[..-3],eval(t[-2..]*n)]}[0]}
+
+p f['2'] # => 2
+p f['2 3 +'] # => 2 + 3 = 5
+p f['20 5 /'] # => 20 / 5 = 4
+p f['4 2 + 3 -'] # => (4 + 2) - 3 = 3
+p f['3 5 8 * 7 + *'] # => ((5 * 8) + 7) * 3 = 141

--- a/2022-09-26-rpn/eu/codegolf/codegolf.rb
+++ b/2022-09-26-rpn/eu/codegolf/codegolf.rb
@@ -6,6 +6,7 @@
 # f=->s{s.split.inject([]){|t,n|/\d/=~n&&t<<(n.to_i)||t[-1]=t[-2].send(n,t.pop);t}[0]}
 # f=->s{s.split.inject([]){|t,n|/\d/=~n ?[*t,n.to_i]:[*t[..-3],t[-2].send(n,t.pop)]}[0]}
 # f=->s{s.split.inject([]){|t,n|/\d/=~n ?[*t,n.to_i]:[*t[..-3],eval(t[-2..]*n)]}[0]}
+# ^^^ git hostory ^^^
 
 f=->s{s.split.inject([]){|t,n|n=~/\d/?[*t,n.to_i]:[*t[..-3],eval(t[-2..]*n)]}[0]}
 


### PR DESCRIPTION
By the rules of codegolf where «f=» can be considered a header, the solution only takes 79 bytes. I wonder if this can be done in less.