### PR TITLE
Code golf solution for dictionary replacer

### DIFF
--- a/2023-02-13-dictionary-replacer/code_golf/README.md
+++ b/2023-02-13-dictionary-replacer/code_golf/README.md
@@ -1,0 +1,5 @@
+# Code Golf Solution
+
+According to code golf counting rules this solution is 42 bytes.
+
+[Try it online!](https://tio.run/##bYxNCoMwEIX3PcUQhqLUKj2AdtNVr6Au/Ik1YBKJcSFqr54mWoRCN8P3Hm8@NZaTaWJzTTwW1P7Mwtcwll6UoRde7n6GkT/XKb7TW54vC57X1fTQpIQEMK/5aWPUlPfoGuKIQJzARlIVaiK/M2ipolBJTgfQLQVRcAro7maAv4oAiFvs9VO2Ah7SpsMsJELNKs2ksHNggzVKDfZfT1/tkXdJM3adE5gP "Ruby – Try It Online")

--- a/2023-02-13-dictionary-replacer/code_golf/dict_repl.rb
+++ b/2023-02-13-dictionary-replacer/code_golf/dict_repl.rb
@@ -1,0 +1,6 @@
+f=->(i,d){i.gsub(/\$(.*?)\$/){d[$~[1]]||$&}}
+
+p f["", {}]
+p f["$temp$", {"temp" => "temporary"}]
+p f["$temp$ here comes the name $name$", { "temp" => "temporary", "name" => "John Doe" }]
+p f["$no$ dictionary is $not empty$", { "not empty" => "full" }]


### PR DESCRIPTION
42 bytes:

```ruby
->(i,d){i.gsub(/\$(.+?)\$/){d[$~[1]]||$&}}
```

[Try it online!](https://tio.run/##bYxNCoMwEIX3PcUQhqLUKj2AdtNVr6Au/Ik1YBKJcSFqr54mWoRCN8P3Hm8@NZaTaWJzTTwW1P7Mwtcwll6UoRde7n6GkT/XKb7TW54vC57X1fTQpIQEMK/5aWPUlPfoGuKIQJzARlIVaiK/M2ipolBJTgfQLQVRcAro7maAv4oAiFvs9VO2Ah7SpsMsJELNKs2ksHNggzVKDfZfT1/tkXdJM3adE5gP "Ruby – Try It Online")