### PR TITLE
Regex engine exercise. Part II. Shunting Yard

### DIFF
--- a/2023-07-03-ruby-regex/eu/README.md
+++ b/2023-07-03-ruby-regex/eu/README.md
@@ -1,9 +1,28 @@
-# Ruby RSpec TDD Template
+# Regex Engine
 
-This is a minimal setup for ruby TDD code katas. To use it:
+## Part 1. Explicit Concatenation Operators
 
-1. Copy this folder to a new location
-2. Rename «example.rb», «example_spec.rb» files (optional)
-3. Rename classes, functions and requires in the renamed files (optional)
-4. Run `bundle install`
-5. Run `bundle exec rspec`
+Add plus signs explicitly to the regex.
+
+So this: `a b | c (d | e)* f`
+
+Becomes this: `a + b | c + (d | e)* + f`
+
+## Part 2. Shunting Yard
+
+1. Establish operator precedence:
+   1. ‘*’ has the highest priority.
+   2. ‘+’ comes next.
+   3. ‘|’ has the lowest priority.
+2. Create a “Output Queue” and a “Operator Stack”.
+3. Reading characters from left to right…
+   1. If it’s a letter,
+      * Add it to output queue.
+   2. If it’s an operator…
+      * While there exists an operator on top of stack with equal or higher priority, pop it from stack and add it to output queue.
+      * Push the operator into the stack.
+   3. If it’s a ‘(‘
+      * Add it to the operator stack.
+   4. If it’s a ‘)’
+      * Keep popping from the stack and add them to the queue, until you hit a ‘(’, then discard both parentheses.
+4. Fin. Your output queue is the postfix notation.

--- a/2023-07-03-ruby-regex/eu/spec/regex_engine_spec.rb
+++ b/2023-07-03-ruby-regex/eu/spec/regex_engine_spec.rb
@@ -3,23 +3,63 @@ require "regex_engine"
 RSpec.describe RegexEngine do
   subject(:engine) { described_class.new }
 
-  it 'prepares "ab" as "a+b"' do
-    expect(engine.prepare("ab")).to eq("a+b")
+  describe '#prepare' do
+    it 'prepares "ab" as "a+b"' do
+      expect(engine.prepare("ab")).to eq("a+b")
+    end
+
+    it 'prepares "ab|c" as "a+b|c"' do
+      expect(engine.prepare("ab|c")).to eq("a+b|c")
+    end
+
+    it 'prepares "ab|c(d)" as "a+b|c+(d)"' do
+      expect(engine.prepare("ab|c(d)")).to eq("a+b|c+(d)")
+    end
+
+    it 'prepares "ab|c(d|e)*" as "a+b|c+(d|e)*"' do
+      expect(engine.prepare("ab|c(d|e)*")).to eq("a+b|c+(d|e)*")
+    end
+
+    it 'prepares "ab*|c(d|e)*f" as "a+b*|c+(d|e)*+f"' do
+      expect(engine.prepare("ab*|c(d|e)*f")).to eq("a+b*|c+(d|e)*+f")
+    end
   end
 
-  it 'prepares "ab|c" as "a+b|c"' do
-    expect(engine.prepare("ab|c")).to eq("a+b|c")
-  end
+  describe '#shunting_yard' do
+    it 'transforms "a+b" to "ab+"' do
+      expect(engine.shunting_yard('a+b')).to eq('ab+')
+    end
 
-  it 'prepares "ab|c(d)" as "a+b|c+(d)"' do
-    expect(engine.prepare("ab|c(d)")).to eq("a+b|c+(d)")
-  end
+    it 'transforms "a+b+c" to "ab+c+"' do
+      expect(engine.shunting_yard('a+b+c')).to eq('ab+c+')
+    end
 
-  it 'prepares "ab|c(d|e)*" as "a+b|c+(d|e)*"' do
-    expect(engine.prepare("ab|c(d|e)*")).to eq("a+b|c+(d|e)*")
-  end
+    it 'transforms "a|b+c" to "abc+|"' do
+      expect(engine.shunting_yard('a|b+c')).to eq('abc+|')
+    end
 
-  it 'prepares "ab*|c(d|e)*f" as "a+b*|c+(d|e)*+f"' do
-    expect(engine.prepare("ab*|c(d|e)*f")).to eq("a+b*|c+(d|e)*+f")
+    it 'transforms "a|b+c" to "abc+|"' do
+      expect(engine.shunting_yard('a|b+c')).to eq('abc+|')
+    end
+
+    it 'transforms "a|b+c+d|f" to "abc+d+|f|"' do
+      expect(engine.shunting_yard('a|b+c+d|f')).to eq('abc+d+|f|')
+    end
+
+    it 'transforms "a|b*+c" to "ab*c+|"' do
+      expect(engine.shunting_yard('a|b*+c')).to eq('ab*c+|')
+    end
+
+    it 'transforms "a|(b+c)*" to "abc+*|"' do
+      expect(engine.shunting_yard('a|(b+c)*')).to eq('abc+*|')
+    end
+
+    it 'transforms "a|(b|c+d)*" to "abcd+|*|"' do
+      expect(engine.shunting_yard('a|(b|c+d)*')).to eq('abcd+|*|')
+    end
+
+    it 'transforms "a+b|c+(d|e)*+f" to "ab+cde|*+f+|"' do
+      expect(engine.shunting_yard('a+b|c+(d|e)*+f')).to eq('ab+cde|*+f+|')
+    end
   end
 end

--- a/2023-07-03-ruby-regex/us/README.md
+++ b/2023-07-03-ruby-regex/us/README.md
@@ -1,9 +1,28 @@
-# Ruby RSpec TDD Template
+# Regex Engine
 
-This is a minimal setup for ruby TDD code katas. To use it:
+## Part 1. Explicit Concatenation Operators
 
-1. Copy this folder to a new location
-2. Rename «example.rb», «example_spec.rb» files (optional)
-3. Rename classes, functions and requires in the renamed files (optional)
-4. Run `bundle install`
-5. Run `bundle exec rspec`
+Add plus signs explicitly to the regex.
+
+So this: `a b | c (d | e)* f`
+
+Becomes this: `a + b | c + (d | e)* + f`
+
+## Part 2. Shunting Yard
+
+1. Establish operator precedence:
+   1. ‘*’ has the highest priority.
+   2. ‘+’ comes next.
+   3. ‘|’ has the lowest priority.
+2. Create a “Output Queue” and a “Operator Stack”.
+3. Reading characters from left to right…
+   1. If it’s a letter,
+      * Add it to output queue.
+   2. If it’s an operator…
+      * While there exists an operator on top of stack with equal or higher priority, pop it from stack and add it to output queue.
+      * Push the operator into the stack.
+   3. If it’s a ‘(‘
+      * Add it to the operator stack.
+   4. If it’s a ‘)’
+      * Keep popping from the stack and add them to the queue, until you hit a ‘(’, then discard both parentheses.
+4. Fin. Your output queue is the postfix notation.

--- a/2023-07-03-ruby-regex/us/spec/regex_engine_spec.rb
+++ b/2023-07-03-ruby-regex/us/spec/regex_engine_spec.rb
@@ -4,31 +4,63 @@ require "regex_engine"
 # a+b|c+(d|e)*+f
 
 RSpec.describe RegexEngine do
-  it 'Has a definition of "zero"' do
-    expect(described_class.new('').preprocess).to eq('')
+  describe '#do_preprocess' do
+    it 'Has a definition of "zero"' do
+      expect(described_class.new.do_preprocess('')).to eq('')
+    end
+
+    it 'Transforms "ab" into "a+b"' do
+      expect(described_class.new.do_preprocess('ab')).to eq('a+b')
+    end
+
+    it 'Transforms "a*" into "a*"' do
+      expect(described_class.new.do_preprocess('a*')).to eq('a*')
+    end
+
+    it 'Transforms "ab|c(d)" into "a+b|c+(d)"' do
+      expect(described_class.new.do_preprocess('ab|c(d)')).to eq('a+b|c+(d)')
+    end
+
+    it 'Transforms "ab|c(d)f" into "a+b|c+(d)+f"' do
+      expect(described_class.new.do_preprocess('ab|c(d)f')).to eq('a+b|c+(d)+f')
+    end
+
+    it 'Transforms "ab|c(d)(f)" into "a+b|c+(d)+(f)"' do
+      expect(described_class.new.do_preprocess('ab|c(d)(f)')).to eq('a+b|c+(d)+(f)')
+    end
+
+    it 'Transforms "ab|c(d|e)*f" into "a+b|c+(d|e)*+f"' do
+      expect(described_class.new.do_preprocess('ab|c(d|e)*f')).to eq('a+b|c+(d|e)*+f')
+    end
   end
 
-  it 'Transforms "ab" into "a+b"' do
-    expect(described_class.new('ab').preprocess).to eq('a+b')
-  end
+  describe '#do_postfix' do
+    it '' do
+      expect(described_class.new.do_postfix('')).to eq('')
+    end
 
-  it 'Transforms "a*" into "a*"' do
-    expect(described_class.new('a*').preprocess).to eq('a*')
-  end
+    it 'a' do
+      expect(described_class.new.do_postfix('a')).to eq('a')
+    end
 
-  it 'Transforms "ab|c(d)" into "a+b|c+(d)"' do
-    expect(described_class.new('ab|c(d)').preprocess).to eq('a+b|c+(d)')
-  end
+    it 'a+b' do
+      expect(described_class.new.do_postfix('a+b')).to eq('ab+')
+    end
 
-  it 'Transforms "ab|c(d)f" into "a+b|c+(d)+f"' do
-    expect(described_class.new('ab|c(d)f').preprocess).to eq('a+b|c+(d)+f')
-  end
+    it 'a+b|c' do
+      expect(described_class.new.do_postfix('a+b|c')).to eq('ab+c|')
+    end
 
-  it 'Transforms "ab|c(d)(f)" into "a+b|c+(d)+(f)"' do
-    expect(described_class.new('ab|c(d)(f)').preprocess).to eq('a+b|c+(d)+(f)')
-  end
+    it 'a+b+c*|d' do
+      expect(described_class.new.do_postfix('a+b+c*|d')).to eq('ab+c*+d|')
+    end
 
-  it 'Transforms "ab|c(d|e)*f" into "a+b|c+(d|e)*+f"' do
-    expect(described_class.new('ab|c(d|e)*f').preprocess).to eq('a+b|c+(d|e)*+f')
+    it 'a+(b+c)' do
+      expect(described_class.new.do_postfix('a+(b+c)')).to eq('abc++')
+    end
+
+    it 'a+b|c+(d|e)*+f' do
+      expect(described_class.new.do_postfix('a+b|c+(d|e)*+f')).to eq('ab+cde|*+f+|')
+    end
   end
 end


### PR DESCRIPTION
`a+b|c+(d|e)*+f` => `ab+cde|*+f+|`